### PR TITLE
internal/postgres: add GetModuleInfo function

### DIFF
--- a/internal/datasource.go
+++ b/internal/datasource.go
@@ -21,6 +21,9 @@ type DataSource interface {
 	// GetImports returns a slice of import paths imported by the package
 	// specified by path and version.
 	GetImports(ctx context.Context, pkgPath, modulePath, version string) ([]string, error)
+	// GetModuleInfo returns the ModuleInfo corresponding to modulePath and
+	// version.
+	GetModuleInfo(ctx context.Context, modulePath, version string) (*ModuleInfo, error)
 	// GetPathInfo returns information about a path.
 	GetPathInfo(ctx context.Context, path, inModulePath, inVersion string) (outModulePath, outVersion string, isPackage bool, err error)
 	// GetPseudoVersionsForModule returns LegacyModuleInfo for all known
@@ -36,9 +39,6 @@ type DataSource interface {
 	// GetTaggedVersionsForModule returns LegacyModuleInfo for all known tagged
 	// versions for any module containing a package with the given import path.
 	GetTaggedVersionsForPackageSeries(ctx context.Context, pkgPath string) ([]*ModuleInfo, error)
-	// GetModuleInfo returns the ModuleInfo corresponding to modulePath and
-	// version.
-	GetModuleInfo(ctx context.Context, modulePath, version string) (*ModuleInfo, error)
 
 	// TODO(golang/go#39629): Deprecate these methods.
 	//

--- a/internal/datasource.go
+++ b/internal/datasource.go
@@ -36,6 +36,9 @@ type DataSource interface {
 	// GetTaggedVersionsForModule returns LegacyModuleInfo for all known tagged
 	// versions for any module containing a package with the given import path.
 	GetTaggedVersionsForPackageSeries(ctx context.Context, pkgPath string) ([]*ModuleInfo, error)
+	// GetModuleInfo returns the ModuleInfo corresponding to modulePath and
+	// version.
+	GetModuleInfo(ctx context.Context, modulePath, version string) (*ModuleInfo, error)
 
 	// TODO(golang/go#39629): Deprecate these methods.
 	//

--- a/internal/postgres/details.go
+++ b/internal/postgres/details.go
@@ -277,7 +277,7 @@ func (db *DB) GetImportedBy(ctx context.Context, pkgPath, modulePath string, lim
 	return importedby, nil
 }
 
-// GetModuleInfo fetches a Version from the database with the primary key
+// GetModuleInfo fetches a module version from the database with the primary key
 // (module_path, version).
 func (db *DB) GetModuleInfo(ctx context.Context, modulePath string, version string) (_ *internal.ModuleInfo, err error) {
 	defer derrors.Wrap(&err, "GetModuleInfo(ctx, %q, %q)", modulePath, version)
@@ -315,7 +315,7 @@ func (db *DB) GetModuleInfo(ctx context.Context, modulePath string, version stri
 	return &mi, nil
 }
 
-// LegacyGetModuleInfo fetches a Version from the database with the primary key
+// LegacyGetModuleInfo fetches a module version from the database with the primary key
 // (module_path, version).
 func (db *DB) LegacyGetModuleInfo(ctx context.Context, modulePath string, version string) (_ *internal.LegacyModuleInfo, err error) {
 	defer derrors.Wrap(&err, "LegacyGetModuleInfo(ctx, %q, %q)", modulePath, version)

--- a/internal/proxydatasource/datasource.go
+++ b/internal/proxydatasource/datasource.go
@@ -219,6 +219,17 @@ func (ds *DataSource) GetTaggedVersionsForPackageSeries(ctx context.Context, pkg
 	return ds.listPackageVersions(ctx, pkgPath, false)
 }
 
+// GetModuleInfo returns the ModuleInfo as fetched from the proxy for module
+// version specified by modulePath and version.
+func (ds *DataSource) GetModuleInfo(ctx context.Context, modulePath, version string) (_ *internal.ModuleInfo, err error) {
+	defer derrors.Wrap(&err, "GetModuleInfo(%q, %q)", modulePath, version)
+	m, err := ds.getModule(ctx, modulePath, version)
+	if err != nil {
+		return nil, err
+	}
+	return &m.ModuleInfo, nil
+}
+
 // LegacyGetModuleInfo returns the LegacyModuleInfo as fetched from the proxy for module
 // version specified by modulePath and version.
 func (ds *DataSource) LegacyGetModuleInfo(ctx context.Context, modulePath, version string) (_ *internal.LegacyModuleInfo, err error) {

--- a/internal/proxydatasource/datasource_test.go
+++ b/internal/proxydatasource/datasource_test.go
@@ -132,6 +132,18 @@ func TestDataSource_LegacyGetModuleInfo_Latest(t *testing.T) {
 	}
 }
 
+func TestDataSource_GetModuleInfo(t *testing.T) {
+	ctx, ds, teardown := setup(t)
+	defer teardown()
+	got, err := ds.GetModuleInfo(ctx, "foo.com/bar", "v1.2.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(&wantModuleInfo, got, cmpOpts...); diff != "" {
+		t.Errorf("GetModuleInfo diff (-want +got):\n%s", diff)
+	}
+}
+
 func TestDataSource_LegacyGetModuleLicenses(t *testing.T) {
 	ctx, ds, teardown := setup(t)
 	defer teardown()


### PR DESCRIPTION
GetModuleInfo returns the ModuleInfo for given module_path and version.
This will replace LegacyGetModuleInfo.

Fixes golang/go#40032