### PR TITLE
x/pkgsite: Adding function to setup server

### DIFF
--- a/internal/frontend/server.go
+++ b/internal/frontend/server.go
@@ -449,3 +449,18 @@ func parsePageTemplates(base template.TrustedSource) (map[string]*template.Templ
 	}
 	return templates, nil
 }
+
+// CreateAndInstallServer creates a new server object, and installs and registers the routes given to it.
+func CreateAndInstallServer(config ServerConfig, handle func(string, http.Handler), redisClient *redis.Client)(*Server, error){
+	server, err := NewServer(config)
+	if err != nil{
+		return nil, err
+	}
+	if redisClient != nil{
+		server.Install(handle, redisClient)
+	}else{
+		server.Install(handle, nil)
+	}
+
+	return server, nil
+}

--- a/internal/frontend/server_test.go
+++ b/internal/frontend/server_test.go
@@ -997,19 +997,19 @@ func newTestServer(t *testing.T, proxyModules []*proxy.TestModule, experimentNam
 			return FetchAndUpdateState(ctx, mpath, version, proxyClient, sourceClient, testDB)
 		})
 
-	s, err := NewServer(ServerConfig{
+	config := ServerConfig{
 		DataSource:           testDB,
 		Queue:                q,
 		TaskIDChangeInterval: 10 * time.Minute,
 		StaticPath:           template.TrustedSourceFromConstant("../../content/static"),
 		ThirdPartyPath:       "../../third_party",
 		AppVersionLabel:      "",
-	})
+	}
+	mux := http.NewServeMux()
+	s, err := CreateAndInstallServer(config, mux.Handle, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mux := http.NewServeMux()
-	s.Install(mux.Handle, nil)
 
 	var exps []*internal.Experiment
 	for _, n := range experimentNames {

--- a/internal/testing/integration/frontend_test.go
+++ b/internal/testing/integration/frontend_test.go
@@ -166,8 +166,7 @@ func TestModulePackageDirectoryResolution(t *testing.T) {
 	}
 }
 
-// TODO(https://github.com/golang/go/issues/40096): factor out this code reduce
-// duplication
+
 func setupFrontend(ctx context.Context, t *testing.T, q queue.Queue) *httptest.Server {
 	t.Helper()
 	config := frontend.ServerConfig{

--- a/internal/testing/integration/frontend_test.go
+++ b/internal/testing/integration/frontend_test.go
@@ -170,7 +170,7 @@ func TestModulePackageDirectoryResolution(t *testing.T) {
 // duplication
 func setupFrontend(ctx context.Context, t *testing.T, q queue.Queue) *httptest.Server {
 	t.Helper()
-	s, err := frontend.NewServer(frontend.ServerConfig{
+	config := frontend.ServerConfig{
 		DataSource:           testDB,
 		TaskIDChangeInterval: 10 * time.Minute,
 		StaticPath:           template.TrustedSourceFromConstant("../../../content/static"),
@@ -178,11 +178,12 @@ func setupFrontend(ctx context.Context, t *testing.T, q queue.Queue) *httptest.S
 		AppVersionLabel:      "",
 		Queue:                q,
 	})
+
+	mux := http.NewServeMux()
+	s, err := frontend.CreateAndInstallServer(config, mux.Handle, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mux := http.NewServeMux()
-	s.Install(mux.Handle, nil)
 
 	experimenter, err := middleware.NewExperimenter(ctx, 1*time.Minute, testDB)
 	if err != nil {

--- a/internal/testing/integration/frontend_test.go
+++ b/internal/testing/integration/frontend_test.go
@@ -166,7 +166,6 @@ func TestModulePackageDirectoryResolution(t *testing.T) {
 	}
 }
 
-
 func setupFrontend(ctx context.Context, t *testing.T, q queue.Queue) *httptest.Server {
 	t.Helper()
 	config := frontend.ServerConfig{
@@ -176,7 +175,7 @@ func setupFrontend(ctx context.Context, t *testing.T, q queue.Queue) *httptest.S
 		ThirdPartyPath:       "../../../third_party",
 		AppVersionLabel:      "",
 		Queue:                q,
-	})
+	}
 
 	mux := http.NewServeMux()
 	s, err := frontend.CreateAndInstallServer(config, mux.Handle, nil)


### PR DESCRIPTION
**What changes does this PR bring?**

- This PR implements a new function, ```CreateAndInstallServer()```, which refactors duplicated parts of code surrounding the creation and installation of routes and places it into this function. 

- For now, I've placed this function within the server.go - please tell me if there's a better place for it! 

Thank you all very much in advance for your feedback :D 