### PR TITLE
x/pkgsite: Fix the width of Subdirectories table

### DIFF
--- a/content/static/css/stylesheet.css
+++ b/content/static/css/stylesheet.css
@@ -1354,10 +1354,10 @@ table.Directories {
   max-width: 800px;
 }
 .Directories td {
-  padding: 0.75rem 0;
   border-bottom: 0.0625rem solid var(--gray-8);
-  padding-right: 1rem;
   max-width: 30rem;
+  padding: 0.75rem 0;
+  padding-right: 1rem;
 }
 .Directories th {
   text-align: left;


### PR DESCRIPTION
The subdirectories table is overflowing for package
https://pkg.go.dev//k8s.io/kubernetes hence adding a maximum width
to the table.

Fixes golang/go#40946