### PR TITLE
internal/fetch/dochtml/internal/render: remove obsolete TODO comment

### DIFF
--- a/internal/fetch/dochtml/internal/render/render.go
+++ b/internal/fetch/dochtml/internal/render/render.go
@@ -17,8 +17,6 @@ import (
 	"golang.org/x/pkgsite/internal/fetch/internal/doc"
 )
 
-// TODO: Hide slice elements and long strings to avoid overwhelming godoc.
-
 var (
 	// Regexp for headings.
 	headingHead = `^[\p{Lu}]`                                  // any uppercase letter


### PR DESCRIPTION
This task was resolved via declVisitor in commit c29176c6819e2879ed1a47f13ce56ec79ca5923b.