### PR TITLE
x/pkgsite: add sourcegraph redirection link for code components

### DIFF
--- a/content/static/css/stylesheet.css
+++ b/content/static/css/stylesheet.css
@@ -1195,6 +1195,13 @@ code {
 .Documentation h3 a.Documentation-source {
   opacity: 1;
 }
+
+.Documentation h3 a.Documentation-uses {
+  color: #666;
+  font-size: 0.8em;
+  opacity: 0;
+}
+
 .Documentation h2:hover a,
 .Documentation h3:hover a,
 .Documentation summary:hover a,

--- a/internal/godoc/dochtml/dochtml_test.go
+++ b/internal/godoc/dochtml/dochtml_test.go
@@ -28,6 +28,7 @@ func TestRender(t *testing.T) {
 	rawDoc, err := Render(context.Background(), fset, d, RenderOptions{
 		FileLinkFunc:   func(string) string { return "file" },
 		SourceLinkFunc: func(ast.Node) string { return "src" },
+		UsesLinkFunc:   func([]string) string { return "uses" },
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/godoc/dochtml/internal/render/idents.go
+++ b/internal/godoc/dochtml/internal/render/idents.go
@@ -318,6 +318,14 @@ type Link struct {
 var LinkTemplate = template.Must(template.New("link").Parse(
 	`<a {{with .Class}}class="{{.}}" {{end}}href="{{.Href}}">{{.Text}}</a>`))
 
+type SourcegraphLink struct {
+	Href, Text, Class string
+	Title             string // title for tooltip when the user's cursor hovers
+}
+
+var SourcegraphLinkTemplate = template.Must(template.New("sourcegraph_link").Parse(
+	`<a class="{{.Class}}" title="{{.Title}}" href="{{.Href}}">{{.Text}}</a>`))
+
 // lookup looks up a dot-separated identifier.
 // E.g., "pkg", "pkg.Var", "Recv.Method", "Struct.Field", "pkg.Struct.Field"
 func (r identifierResolver) lookup(id string) (pkgPath, name string, ok bool) {

--- a/internal/godoc/dochtml/legacy_body.go
+++ b/internal/godoc/dochtml/legacy_body.go
@@ -90,7 +90,7 @@ const legacyTmplBody = `
 		{{- range .Funcs -}}
 		<div class="Documentation-function">
 			{{- $id := safe_id .Name -}}
-			<h3 tabindex="-1" id="{{$id}}" data-kind="function" class="Documentation-functionHeader">func {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a></h3>{{"\n"}}
+			<h3 tabindex="-1" id="{{$id}}" data-kind="function" class="Documentation-functionHeader">func {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a> {{uses_link "List Function Callers" .Name}}</h3>{{"\n"}}
 			{{- $out := render_decl .Doc .Decl -}}
 			{{- $out.Decl -}}
 			{{- $out.Doc -}}
@@ -107,7 +107,7 @@ const legacyTmplBody = `
 		<div class="Documentation-type">
 			{{- $tname := .Name -}}
 			{{- $id := safe_id .Name -}}
-			<h3 tabindex="-1" id="{{$id}}" data-kind="type" class="Documentation-typeHeader">type {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a></h3>{{"\n"}}
+			<h3 tabindex="-1" id="{{$id}}" data-kind="type" class="Documentation-typeHeader">type {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a> {{uses_link "List Uses of This Type" .Name}}</h3>{{"\n"}}
 			{{- $out := render_decl .Doc .Decl -}}
 			{{- $out.Decl -}}
 			{{- $out.Doc -}}
@@ -135,7 +135,7 @@ const legacyTmplBody = `
 			{{- range .Funcs -}}
 			<div class="Documentation-typeFunc">
 				{{- $id := safe_id .Name -}}
-				<h3 tabindex="-1" id="{{$id}}" data-kind="function" class="Documentation-typeFuncHeader">func {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a></h3>{{"\n"}}
+				<h3 tabindex="-1" id="{{$id}}" data-kind="function" class="Documentation-typeFuncHeader">func {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a> {{uses_link "List Function Callers" .Name}}</h3>{{"\n"}}
 				{{- $out := render_decl .Doc .Decl -}}
 				{{- $out.Decl -}}
 				{{- $out.Doc -}}
@@ -148,7 +148,7 @@ const legacyTmplBody = `
 			<div class="Documentation-typeMethod">
 				{{- $name := (printf "%s.%s" $tname .Name) -}}
 				{{- $id := (safe_id $name) -}}
-				<h3 tabindex="-1" id="{{$id}}" data-kind="method" class="Documentation-typeMethodHeader">func ({{.Recv}}) {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a></h3>{{"\n"}}
+				<h3 tabindex="-1" id="{{$id}}" data-kind="method" class="Documentation-typeMethodHeader">func ({{.Recv}}) {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a>  {{uses_link "List Method Callers" .Recv .Name}}</h3>{{"\n"}}
 				{{- $out := render_decl .Doc .Decl -}}
 				{{- $out.Decl -}}
 				{{- $out.Doc -}}

--- a/internal/godoc/dochtml/legacy_template_test.go
+++ b/internal/godoc/dochtml/legacy_template_test.go
@@ -254,7 +254,7 @@ const fullTemplate = `{{- "" -}}
 		{{- range .Funcs -}}
 		<div class="Documentation-function">
 			{{- $id := safe_id .Name -}}
-			<h3 tabindex="-1" id="{{$id}}" data-kind="function" class="Documentation-functionHeader">func {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a></h3>{{"\n"}}
+			<h3 tabindex="-1" id="{{$id}}" data-kind="function" class="Documentation-functionHeader">func {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a> {{uses_link "List Function Callers" .Name}}</h3>{{"\n"}}
 			{{- $out := render_decl .Doc .Decl -}}
 			{{- $out.Decl -}}
 			{{- $out.Doc -}}
@@ -271,7 +271,7 @@ const fullTemplate = `{{- "" -}}
 		<div class="Documentation-type">
 			{{- $tname := .Name -}}
 			{{- $id := safe_id .Name -}}
-			<h3 tabindex="-1" id="{{$id}}" data-kind="type" class="Documentation-typeHeader">type {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a></h3>{{"\n"}}
+			<h3 tabindex="-1" id="{{$id}}" data-kind="type" class="Documentation-typeHeader">type {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a> {{uses_link "List Uses of This Type" .Name}}</h3>{{"\n"}}
 			{{- $out := render_decl .Doc .Decl -}}
 			{{- $out.Decl -}}
 			{{- $out.Doc -}}
@@ -299,7 +299,7 @@ const fullTemplate = `{{- "" -}}
 			{{- range .Funcs -}}
 			<div class="Documentation-typeFunc">
 				{{- $id := safe_id .Name -}}
-				<h3 tabindex="-1" id="{{$id}}" data-kind="function" class="Documentation-typeFuncHeader">func {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a></h3>{{"\n"}}
+				<h3 tabindex="-1" id="{{$id}}" data-kind="function" class="Documentation-typeFuncHeader">func {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a> {{uses_link "List Function Callers" .Name}}</h3>{{"\n"}}
 				{{- $out := render_decl .Doc .Decl -}}
 				{{- $out.Decl -}}
 				{{- $out.Doc -}}
@@ -312,7 +312,7 @@ const fullTemplate = `{{- "" -}}
 			<div class="Documentation-typeMethod">
 				{{- $name := (printf "%s.%s" $tname .Name) -}}
 				{{- $id := (safe_id $name) -}}
-				<h3 tabindex="-1" id="{{$id}}" data-kind="method" class="Documentation-typeMethodHeader">func ({{.Recv}}) {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a></h3>{{"\n"}}
+				<h3 tabindex="-1" id="{{$id}}" data-kind="method" class="Documentation-typeMethodHeader">func ({{.Recv}}) {{source_link .Name .Decl}} <a href="#{{$id}}">¶</a>  {{uses_link "List Method Callers" .Recv .Name}}</h3>{{"\n"}}
 				{{- $out := render_decl .Doc .Decl -}}
 				{{- $out.Decl -}}
 				{{- $out.Doc -}}

--- a/internal/godoc/dochtml/template.go
+++ b/internal/godoc/dochtml/template.go
@@ -49,6 +49,7 @@ var tmpl = map[string]interface{}{
 	"render_code":           (*render.Renderer)(nil).CodeHTML,
 	"file_link":             func() string { return "" },
 	"source_link":           func() string { return "" },
+	"uses_link":             func() string { return "" },
 	"play_url":              func(*doc.Example) string { return "" },
 	"safe_id":               render.SafeGoID,
 }

--- a/internal/godoc/render.go
+++ b/internal/godoc/render.go
@@ -119,10 +119,17 @@ func (p *Package) Render(ctx context.Context, innerPath string, sourceInfo *sour
 		}
 		return sourceInfo.FileURL(path.Join(innerPath, filename))
 	}
+	usesLinkFunc := func(defParts []string) string {
+		if sourceInfo == nil {
+			return ""
+		}
+		return sourceInfo.UsesURL(modInfo.ModulePath, importPath, defParts)
+	}
 
 	docHTML, err := dochtml.Render(ctx, p.Fset, d, dochtml.RenderOptions{
 		FileLinkFunc:   fileLinkFunc,
 		SourceLinkFunc: sourceLinkFunc,
+		UsesLinkFunc:   usesLinkFunc,
 		ModInfo:        modInfo,
 		Limit:          int64(MaxDocumentationHTML),
 	})


### PR DESCRIPTION
The godoc.org has a "Uses" link that redirects to Sourcegraph website for showing the usage/callers of types, functions, and methods.
This PR implements the same functionality for pkg.go.dev. Much inspired by Quinn's (@sqs) PR on gddo (github.com/golang/gddo/pull/259).
A short demo can be seen at https://youtu.be/OathLmQVM5g.

Fixes #39703