### PR TITLE
x/pkgsite: fix migration 000032 and add migration 000033

### DIFF
--- a/migrations/000033_drop_search_documents_package_path_module_path_version_fkey.down.sql
+++ b/migrations/000033_drop_search_documents_package_path_module_path_version_fkey.down.sql
@@ -1,0 +1,12 @@
+-- Copyright 2020 The Go Authors. All rights reserved.
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file.
+
+BEGIN;
+
+ALTER TABLE search_documents
+    ADD CONSTRAINT search_documents_package_path_module_path_version_fkey
+        FOREIGN KEY (package_path, module_path, version)
+        REFERENCES packages(path, module_path, version) ON DELETE CASCADE;
+
+END;

--- a/migrations/000033_drop_search_documents_package_path_module_path_version_fkey.up.sql
+++ b/migrations/000033_drop_search_documents_package_path_module_path_version_fkey.up.sql
@@ -4,6 +4,6 @@
 
 BEGIN;
 
-ALTER TABLE search_documents DROP CONSTRAINT IF EXISTS search_documents_package_path_fkey;
+ALTER TABLE search_documents DROP CONSTRAINT IF EXISTS search_documents_package_path_module_path_version_fkey;
 
 END;


### PR DESCRIPTION
The initial foreign key constraint (from patch 000001) was configured as
FOREIGN KEY (package_path, module_path, version) which Postgres maps to
search_documents_package_path_module_path_version_fkey, rather than the
search_documents_package_path_fkey which was dropped in patch 000032.