### PR TITLE
x/pkgsite: mark unit meta as redistributable in license bypass mode

### DIFF
--- a/internal/postgres/licenses_test.go
+++ b/internal/postgres/licenses_test.go
@@ -205,3 +205,16 @@ func nonRedistributableModule() *internal.Module {
 	m.Units[0].IsRedistributable = false
 	return m
 }
+
+func makeModuleNonRedistributable(m *internal.Module) {
+	sample.AddLicense(m, sample.NonRedistributableLicense)
+	m.IsRedistributable = false
+
+	for _, p := range m.Packages() {
+		p.IsRedistributable = false
+	}
+
+	for i := range m.Units {
+		m.Units[i].IsRedistributable = false
+	}
+}

--- a/internal/postgres/licenses_test.go
+++ b/internal/postgres/licenses_test.go
@@ -206,6 +206,10 @@ func nonRedistributableModule() *internal.Module {
 	return m
 }
 
+// makeModuleNonRedistributable mutates the passed-in module by marking it
+// non-redistributable along with each of its packages and units. It allows
+// us to re-use existing test data without defining a non-redistributable
+// countepart to each.
 func makeModuleNonRedistributable(m *internal.Module) {
 	sample.AddLicense(m, sample.NonRedistributableLicense)
 	m.IsRedistributable = false

--- a/internal/postgres/path.go
+++ b/internal/postgres/path.go
@@ -110,6 +110,11 @@ func (db *DB) GetUnitMeta(ctx context.Context, path, requestedModulePath, reques
 		if err != nil {
 			return nil, err
 		}
+
+		if db.bypassLicenseCheck {
+			um.IsRedistributable = true
+		}
+
 		um.Licenses = lics
 		return &um, nil
 	default:

--- a/internal/postgres/path_test.go
+++ b/internal/postgres/path_test.go
@@ -6,6 +6,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -193,6 +194,199 @@ func TestGetUnitMeta(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestGetUnitMetaBypass(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	defer ResetTestDB(testDB, t)
+	bypassDB := NewBypassingLicenseCheck(testDB.db)
+
+	for _, testModule := range []struct {
+		module, version, packageSuffix string
+		isMaster                       bool
+	}{
+		{"m.com", "v1.0.0", "a", false},
+		{"m.com", "v1.0.1", "dir/a", false},
+		{"m.com", "v1.1.0", "a/b", false},
+		{"m.com", "v1.2.0-pre", "a", true},
+		{"m.com", "v2.0.0+incompatible", "a", false},
+		{"m.com/a", "v1.1.0", "b", false},
+		{"m.com/b", "v2.0.0+incompatible", "a", true},
+	} {
+		m := sample.LegacyModule(testModule.module, testModule.version, testModule.packageSuffix)
+		makeModuleNonRedistributable(m)
+
+		if err := bypassDB.InsertModule(ctx, m); err != nil {
+			t.Fatal(err)
+		}
+		requested := m.Version
+		if testModule.isMaster {
+			requested = internal.MasterVersion
+		}
+		if err := bypassDB.UpsertVersionMap(ctx, &internal.VersionMap{
+			ModulePath:       m.ModulePath,
+			RequestedVersion: requested,
+			ResolvedVersion:  m.Version,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, bypassLicenseCheck := range []bool{false, true} {
+		for _, test := range []struct {
+			name                  string
+			path, module, version string
+			want                  *internal.UnitMeta
+		}{
+			{
+				name:    "known module and version",
+				path:    "m.com/a",
+				module:  "m.com",
+				version: "v1.2.0-pre",
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com",
+					Version:           "v1.2.0-pre",
+					Name:              "a",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name:    "unknown module, known version",
+				path:    "m.com/a/b",
+				version: "v1.1.0",
+				// The path is in two modules at v1.1.0. Prefer the longer one.
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com/a",
+					Version:           "v1.1.0",
+					Name:              "b",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name:   "known module, unknown version",
+				path:   "m.com/a",
+				module: "m.com",
+				// Choose the latest release version.
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com",
+					Version:           "v1.1.0",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name: "unknown module and version",
+				path: "m.com/a/b",
+				// Select the latest release version, longest module.
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com/a",
+					Version:           "v1.1.0",
+					Name:              "b",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name: "module",
+				path: "m.com",
+				// Select the latest version of the module.
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com",
+					Version:           "v1.1.0",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name:    "longest module",
+				path:    "m.com/a",
+				version: "v1.1.0",
+				// Prefer module m/a over module m, directory a.
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com/a",
+					Version:           "v1.1.0",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name: "directory",
+				path: "m.com/dir",
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com",
+					Version:           "v1.0.1",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name:    "module at master version",
+				path:    "m.com",
+				version: "master",
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com",
+					Version:           "v1.2.0-pre",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name:    "package at master version",
+				path:    "m.com/a",
+				version: "master",
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com",
+					Version:           "v1.2.0-pre",
+					Name:              "a",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+			{
+				name:    "incompatible module",
+				path:    "m.com/b",
+				version: "master",
+				want: &internal.UnitMeta{
+					ModulePath:        "m.com/b",
+					Version:           "v2.0.0+incompatible",
+					IsRedistributable: bypassLicenseCheck,
+				},
+			},
+		} {
+			name := fmt.Sprintf("bypass %v %s", bypassLicenseCheck, test.name)
+			t.Run(name, func(t *testing.T) {
+				if test.module == "" {
+					test.module = internal.UnknownModulePath
+				}
+				if test.version == "" {
+					test.version = internal.LatestVersion
+				}
+				test.want = sample.UnitMeta(
+					test.path,
+					test.want.ModulePath,
+					test.want.Version,
+					test.want.Name,
+					test.want.IsRedistributable,
+				)
+				test.want.CommitTime = sample.CommitTime
+
+				var db *DB
+
+				if bypassLicenseCheck {
+					db = bypassDB
+				} else {
+					db = testDB
+				}
+
+				got, err := db.GetUnitMeta(ctx, test.path, test.module, test.version)
+				if err != nil {
+					t.Fatal(err)
+				}
+				opts := []cmp.Option{
+					cmpopts.IgnoreFields(licenses.Metadata{}, "Coverage"),
+					cmp.AllowUnexported(source.Info{}, safehtml.HTML{}),
+				}
+				if diff := cmp.Diff(test.want, got, opts...); diff != "" {
+					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
Without this, the frontend is unable to display doc contents for
non-redistributable packages even when in license bypass mode.