### PR TITLE
x/pkgsite: support versions tab for directory view

### DIFF
--- a/internal/frontend/tabs.go
+++ b/internal/frontend/tabs.go
@@ -198,6 +198,8 @@ func fetchDetailsForDirectory(r *http.Request, tab string, ds internal.DataSourc
 		return fetchDirectoryDetails(ctx, ds, um, false)
 	case legacyTabLicenses:
 		return fetchLicensesDetails(ctx, ds, um)
+	case tabVersions:
+		return fetchVersionsDetails(ctx, ds, um.Path, um.ModulePath)
 	}
 	return nil, fmt.Errorf("BUG: unable to fetch details: unknown tab %q", tab)
 }


### PR DESCRIPTION
Added a new case for directory view to fetch version details for the directory

Fixes: golang/go#40942