### PR TITLE
content/static/css: fix overflow on homepage.

### DIFF
--- a/content/static/css/homepage.css
+++ b/content/static/css/homepage.css
@@ -117,7 +117,6 @@ a.Homepage-helpLink {
   color: var(--gray-2);
   display: flex;
   padding: 0.5rem 0;
-  width: 100vw;
 }
 .Questions-header {
   color: var(--gray-2);


### PR DESCRIPTION
The overflow was caused by oversized div with css class `.Questions`. Removed `width:100vw` to avoid overflow.

fixes https://github.com/golang/go/issues/42718