### PR TITLE
content/static/css: make .JumpDialog's position fixed.

### DIFF
--- a/content/static/css/stylesheet.css
+++ b/content/static/css/stylesheet.css
@@ -1587,6 +1587,7 @@ table.Directories {
 }
 
 .JumpDialog {
+  position: fixed;
   width: 25rem;
 }
 .JumpDialog-body {


### PR DESCRIPTION
add `position:fixed;` to `.JumpDialog` class to always keep it on visible viewport even if the page is scrolled.
fixes golang/go#43840