### PR TITLE
content/static/css: make .Dialog's position fixed

### DIFF
--- a/content/static/css/stylesheet.css
+++ b/content/static/css/stylesheet.css
@@ -1563,6 +1563,7 @@ table.Directories {
 
 .Dialog {
   padding: 0;
+  position: fixed;
   border: 0.0625rem solid rgba(0, 0, 0, 0.2);
   border-radius: 6px;
   box-shadow: 0 0.3125rem 0.9375rem rgba(0, 0, 0, 0.5);
@@ -1587,7 +1588,6 @@ table.Directories {
 }
 
 .JumpDialog {
-  position: fixed;
   width: 25rem;
 }
 .JumpDialog-body {


### PR DESCRIPTION
Add `position:fixed` in `.Dialog` class to make appearance of both
`.JumpDialog` and `ShortcutsDialog` consistent

Fixes golang/go#43877