### PR TITLE
internal/licenses: add exception for a single bundled dependency pointer

### DIFF
--- a/internal/licenses/exceptions/atc-dependency.lre
+++ b/internal/licenses/exceptions/atc-dependency.lre
@@ -1,0 +1,15 @@
+//**
+source: https://github.com/apache/trafficcontrol/blob/master/LICENSE
+**//
+{{Types "Apache-2.0 BSD-2-Clause BSD-3-Clause MIT"}}
+
+This product bundles __15__, which
+(( is || are ))
+available under
+(( a || an ))
+(("))??
+(( Apache-2.0 || BSD-2-Clause || BSD-3-Clause || MIT ))
+(("))??
+license.
+__40__
+Refer to the above license for the full text.


### PR DESCRIPTION
Apache projects are instructed to include a "pointer" in the LICENSE for
each permissively-licensed dependency that the project bundles.

The format follows instructions from https://infra.apache.org/licensing-howto.html#permissive-deps

Fixes golang/go#44968

Co-authored-by: alficles <alficles@gmail.com>