### PR TITLE
internal/licenses: Increase unidentified words allowed in atc exception

### DIFF
--- a/internal/licenses/exceptions.gen.go
+++ b/internal/licenses/exceptions.gen.go
@@ -6123,7 +6123,7 @@ source: https://github.com/apache/trafficcontrol/blob/master/LICENSE
 **//
 
 
-This product bundles __3__, which
+This product bundles __4__, which
 (( is || are ))
 available under
 (( a || an ))
@@ -6131,7 +6131,7 @@ available under
 license.
 __15__
 (( /* || .css || .js || .scss ))
-(( ./licenses/__4__ || ./vendor/__15__/LICENSE
+(( ./licenses/__4__ || ./vendor/__16__/LICENSE
 (( .libyaml || .md || .txt ))??
 ))
 Refer to the above license for the full text.

--- a/internal/licenses/exceptions/atc-dependency.lre
+++ b/internal/licenses/exceptions/atc-dependency.lre
@@ -3,7 +3,7 @@ source: https://github.com/apache/trafficcontrol/blob/master/LICENSE
 **//
 {{Types "Apache-2.0 BSD-2-Clause BSD-3-Clause MIT"}}
 
-This product bundles __3__, which
+This product bundles __4__, which
 (( is || are ))
 available under
 (( a || an ))
@@ -11,7 +11,7 @@ available under
 license.
 __15__
 (( /* || .css || .js || .scss ))
-(( ./licenses/__4__ || ./vendor/__15__/LICENSE
+(( ./licenses/__4__ || ./vendor/__16__/LICENSE
 (( .libyaml || .md || .txt ))??
 ))
 Refer to the above license for the full text.


### PR DESCRIPTION
Increase the number of unidentified words accepted by the atc-dependency
license exception for package and repo names by 1.

The current atc license exception works for the Apache Traffic Control
master branch, but the 5.1.x release branch license
(https://github.com/apache/trafficcontrol/blob/5.1.x/LICENSE) only has
66% coverage. This CL brings it up to 79%.

For golang/go#44968
