### PR TITLE
x/pkgsite: remove protocol from source code links

### DIFF
--- a/content/static/html/helpers/_unit_meta.tmpl
+++ b/content/static/html/helpers/_unit_meta.tmpl
@@ -17,7 +17,7 @@
     <div class="UnitMeta-repo">
       {{if .Details.RepositoryURL}}
         <a href="{{.Details.RepositoryURL}}" title="{{.Details.RepositoryURL}}" target="_blank" rel="noopener">
-          {{.Details.RepositoryURL}}
+          {{stripscheme .Details.RepositoryURL}}
         </a>
       {{else}}
         Repository URL not available.

--- a/internal/frontend/server.go
+++ b/internal/frontend/server.go
@@ -519,6 +519,15 @@ var templateFuncs = template.FuncMap{
 	"commaseparate": func(s []string) string {
 		return strings.Join(s, ", ")
 	},
+	"stripscheme": stripscheme,
+}
+
+func stripscheme(url string) string {
+	if i := strings.Index(url, "://"); i > 0 {
+		return url[i+len("://"):]
+	}
+
+	return url
 }
 
 // parsePageTemplates parses html templates contained in the given base

--- a/internal/frontend/server_test.go
+++ b/internal/frontend/server_test.go
@@ -1626,3 +1626,19 @@ func TestEmptyDirectoryBetweenNestedModulesRedirect(t *testing.T) {
 		})
 	}
 }
+
+func TestStripScheme(t *testing.T) {
+	cases := map[string]string{
+		"http://github.com":                    "github.com",
+		"https://github.com/path/to/something": "github.com/path/to/something",
+		"example.com":                          "example.com",
+		"chrome-extension://abcd":              "abcd",
+		"nonwellformed.com/path?://query=1":    "query=1",
+	}
+
+	for url, expected := range cases {
+		if actual := stripscheme(url); actual != expected {
+			t.Errorf("Failed for %q: got %q, want %q", url, actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
A new template function for stripping scheme from URL applied to repository
URL in the Details block.

Fixes golang/go#40943