### PR TITLE
internal/fetch: fix extractReadmes  work on _directories

### DIFF
--- a/internal/fetch/readme.go
+++ b/internal/fetch/readme.go
@@ -24,10 +24,20 @@ func extractReadmes(modulePath, resolvedVersion string, contentDir fs.FS) (_ []*
 	// The key is the README directory. Since we only store one README file per
 	// directory, we use this below to prioritize READMEs in markdown.
 	readmes := map[string]*internal.Readme{}
+	var skipPaths = []string{"_"}
 	err = fs.WalkDir(contentDir, ".", func(pathname string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
+		for _, sp := range skipPaths {
+			// if the name of the folder has a prefix listed in skipPaths
+			// then we should skip the directory.
+			// e.g.  _foo
+			if strings.HasPrefix(pathname, sp) {
+				return fs.SkipDir
+			}
+		}
+
 		if !d.IsDir() && isReadme(pathname) {
 			info, err := d.Info()
 			if err != nil {

--- a/internal/fetch/readme_test.go
+++ b/internal/fetch/readme_test.go
@@ -45,6 +45,17 @@ func TestExtractReadmes(t *testing.T) {
 			},
 		},
 		{
+			name:       "directory start with _",
+			modulePath: stdlib.ModulePath,
+			version:    "v1.12.5",
+			want: []*internal.Readme{
+				{
+					Filepath: "cmd/pprof/README",
+					Contents: "This directory is the copy of Google's pprof shipped as part of the Go distribution.\n",
+				},
+			},
+		},
+		{
 			name:       "prefer README.md",
 			modulePath: "github.com/my/module",
 			version:    "v1.0.0",

--- a/internal/stdlib/testdata/v1.12.5/src/_foo/README.md
+++ b/internal/stdlib/testdata/v1.12.5/src/_foo/README.md
@@ -1,0 +1,1 @@
+Can not read content


### PR DESCRIPTION
Fixes golang/go#54388 