### PR TITLE
x/pkgsite: add -open to open browser

### DIFF
--- a/cmd/pkgsite/main.go
+++ b/cmd/pkgsite/main.go
@@ -150,6 +150,9 @@ func main() {
 	log.Infof(ctx, "Listening on addr http://%s", *httpAddr)
 	if *openFlag {
 		go func() {
+			// Small delay to give the server chance to start with
+			// http.ListenAndServe call below, otherwise the browser
+			// could send the request before we're ready to serve.
 			time.Sleep(100 * time.Millisecond)
 			if !browser.Open("http://" + *httpAddr) {
 				log.Infof(ctx, "Failed to open browser window. Please visit http://%s in your browser.", *httpAddr)

--- a/cmd/pkgsite/main.go
+++ b/cmd/pkgsite/main.go
@@ -65,6 +65,7 @@ import (
 
 	"github.com/google/safehtml/template"
 	"golang.org/x/pkgsite/internal"
+	"golang.org/x/pkgsite/internal/browser"
 	"golang.org/x/pkgsite/internal/fetch"
 	"golang.org/x/pkgsite/internal/fetchdatasource"
 	"golang.org/x/pkgsite/internal/frontend"
@@ -85,6 +86,7 @@ var (
 	useProxy   = flag.Bool("proxy", false, "fetch from GOPROXY if not found locally")
 	devMode    = flag.Bool("dev", false, "enable developer mode (reload templates on each page load, serve non-minified JS/CSS, etc.)")
 	staticFlag = flag.String("static", "static", "path to folder containing static files served")
+	openFlag   = flag.Bool("open", false, "open a browser window to the server's address")
 	// other flags are bound to serverConfig below
 )
 
@@ -146,6 +148,14 @@ func main() {
 	server.Install(router.Handle, nil, nil)
 	mw := middleware.Timeout(54 * time.Second)
 	log.Infof(ctx, "Listening on addr http://%s", *httpAddr)
+	if *openFlag {
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			if !browser.Open("http://" + *httpAddr) {
+				log.Infof(ctx, "Failed to open browser window. Please visit http://%s in your browser.", *httpAddr)
+			}
+		}()
+	}
 	die("%v", http.ListenAndServe(*httpAddr, mw(router)))
 }
 

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package browser provides utilities for interacting with users' browsers.
+package browser
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// Commands returns a list of possible commands to use to open a url.
+func Commands() [][]string {
+	var cmds [][]string
+	if exe := os.Getenv("BROWSER"); exe != "" {
+		cmds = append(cmds, []string{exe})
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		cmds = append(cmds, []string{"/usr/bin/open"})
+	case "windows":
+		cmds = append(cmds, []string{"cmd", "/c", "start"})
+	default:
+		if os.Getenv("DISPLAY") != "" {
+			// xdg-open is only for use in a desktop environment.
+			cmds = append(cmds, []string{"xdg-open"})
+		}
+	}
+	cmds = append(cmds,
+		[]string{"chrome"},
+		[]string{"google-chrome"},
+		[]string{"chromium"},
+		[]string{"firefox"},
+	)
+	return cmds
+}
+
+// Open tries to open url in a browser and reports whether it succeeded.
+func Open(url string) bool {
+	for _, args := range Commands() {
+		cmd := exec.Command(args[0], append(args[1:], url)...)
+		if cmd.Start() == nil && appearsSuccessful(cmd, 3*time.Second) {
+			return true
+		}
+	}
+	return false
+}
+
+// appearsSuccessful reports whether the command appears to have run successfully.
+// If the command runs longer than the timeout, it's deemed successful.
+// If the command runs within the timeout, it's deemed successful if it exited cleanly.
+func appearsSuccessful(cmd *exec.Cmd, timeout time.Duration) bool {
+	errc := make(chan error, 1)
+	go func() {
+		errc <- cmd.Wait()
+	}()
+
+	select {
+	case <-time.After(timeout):
+		return true
+	case err := <-errc:
+		return err == nil
+	}
+}

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package browser provides utilities for interacting with users' browsers.
+// Copied from: https://go.googlesource.com/go/src/cmd/internal/browser/browser.go
 package browser
 
 import (


### PR DESCRIPTION
Add -open command line flag to cmd/pkgsite which tries to open a browser to the newly running server.

This provides a simple way to open a browser to pkgsite service without having do paste the URL into a browser manually.

It leverages the internal/browser package from go for this functionality as used by go tool cover -html.

Fixes golang/go#60002