### PR TITLE
x/pkgsite: expose Postgres port to loopback

### DIFF
--- a/devtools/docker/compose.yaml
+++ b/devtools/docker/compose.yaml
@@ -121,6 +121,8 @@ services:
       POSTGRES_USER: ${GO_DISCOVERY_DATABASE_USER:-postgres}
     volumes:
       - pgdata:/var/lib/postgresql/data
+    ports:
+      - 127.0.0.1:5432:5432
   nodejs:
     image: node:14.17.0
     environment:


### PR DESCRIPTION
Expose the Postgres port to loopback so that it works under WSL, enabling the tests run by all.bash to complete successfully based on the setup instructions in doc/postgres.md.

Fixes golang/go#60009