### PR TITLE
cmd/frontend: add -local flag to run frontend in LocalMode

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -37,6 +37,7 @@ var (
 	staticFlag     = flag.String("static", "static", "path to folder containing static files served")
 	thirdPartyPath = flag.String("third_party", "third_party", "path to folder containing third-party libraries")
 	devMode        = flag.Bool("dev", false, "enable developer mode (reload templates on each page load, serve non-minified JS/CSS, etc.)")
+	localMode      = flag.Bool("local", false, "enable local mode (hide irrelevant content and links to go.dev)")
 	disableCSP     = flag.Bool("nocsp", false, "disable Content Security Policy")
 	proxyURL       = flag.String("proxy_url", "https://proxy.golang.org", "Uses the module proxy referred to by this URL "+
 		"for direct proxy mode and frontend fetches")
@@ -120,6 +121,7 @@ func main() {
 		StaticPath:           *staticFlag,
 		ThirdPartyFS:         os.DirFS(*thirdPartyPath),
 		DevMode:              *devMode,
+		LocalMode:            *localMode,
 		ReportingClient:      rc,
 		VulndbClient:         vc,
 	})


### PR DESCRIPTION
The frontend UI show/hide elements and links based on whether the frontend server is running in `LocalMode`. For the `frontend` this value is hardcoded to `false`. 

This PR adds the flag `-local` to allow starting the frontend in `LocalMode`. This is particularly beneficial for those who wish to run the `frontend` locally or self-host for internal packages.

Fixes golang/go#60872