### PR TITLE
static/frontend: fix homepage link when running in LocalMode

### DIFF
--- a/static/frontend/styleguide/styleguide.tmpl
+++ b/static/frontend/styleguide/styleguide.tmpl
@@ -42,7 +42,7 @@
   </nav>
   <div class="go-Main-headerContent">
     <div class="go-Main-headerTitle">
-      <a class="go-Main-headerLogo" href="https://go.dev/" aria-hidden="true" tabindex="-1" data-gtmc="header link"
+      <a class="go-Main-headerLogo" href="{{if .LocalMode}}/{{else}}https://go.dev/{{end}}" aria-hidden="true" tabindex="-1" data-gtmc="header link"
           aria-label="Link to Go Homepage">
         <img height="78" width="207" src="/static/shared/logo/go-blue.svg" alt="Go">
       </a>

--- a/static/frontend/unit/_header.tmpl
+++ b/static/frontend/unit/_header.tmpl
@@ -53,7 +53,7 @@
 
 {{define "unit-header-title"}}
   <div class="go-Main-headerTitle js-stickyHeader">
-    <a class="go-Main-headerLogo" href="https://go.dev/" aria-hidden="true" tabindex="-1" data-gtmc="header link" aria-label="Link to Go Homepage">
+    <a class="go-Main-headerLogo" href="{{if .LocalMode}}/{{else}}https://go.dev/{{end}}" aria-hidden="true" tabindex="-1" data-gtmc="header link" aria-label="Link to Go Homepage">
       <img height="78" width="207" src="/static/shared/logo/go-blue.svg" alt="Go">
     </a>
     <h1 class="UnitHeader-titleHeading" data-test-id="UnitHeader-title">{{.Title}}</h1>


### PR DESCRIPTION
Change the homepage link based on whether we are running in LocalMode. If pkgsite or frontend are running in LocalMode, set the href link to "/", otherwise keep "https://go.dev".

Fixes golang/go#60916