### PR TITLE
internal/godoc/dochtml: omit "Output" section for examples with no output

### DIFF
--- a/internal/godoc/dochtml/dochtml_test.go
+++ b/internal/godoc/dochtml/dochtml_test.go
@@ -177,6 +177,32 @@ func main() {
         <button class="Documentation-exampleRunButton" aria-label="Run Code">Run</button>
       </div></details>`,
 		},
+		{
+			name:   "Example without output",
+			htmlID: "example-package-NoOutput",
+			want: `<details tabindex="-1" id="example-package-NoOutput" class="Documentation-exampleDetails js-exampleContainer">
+<summary class="Documentation-exampleDetailsHeader">Example (NoOutput) <a href="#example-package-NoOutput" title="Go to Example (NoOutput)" aria-label="Go to Example (NoOutput)">¶</a></summary>
+<div class="Documentation-exampleDetailsBody">
+
+<pre class="Documentation-exampleCode">package main
+
+import (
+	&#34;fmt&#34;
+)
+
+func main() {
+	fmt.Println(&#34;hello&#34;)
+}
+</pre>
+
+</div>
+<div class="Documentation-exampleButtonsContainer">
+        <p class="Documentation-exampleError" role="alert" aria-atomic="true"></p>
+        <button class="Documentation-exampleShareButton" aria-label="Share Code">Share</button>
+        <button class="Documentation-exampleFormatButton" aria-label="Format Code">Format</button>
+        <button class="Documentation-exampleRunButton" aria-label="Run Code">Run</button>
+      </div></details>`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			diff := cmp.Diff(test.want, got[test.htmlID])

--- a/internal/godoc/dochtml/testdata/example_test.go
+++ b/internal/godoc/dochtml/testdata/example_test.go
@@ -46,3 +46,7 @@ func Example_stringsCompare() {
 	// 0
 	// 1
 }
+
+func Example_noOutput() {
+	fmt.Println("hello")
+}

--- a/static/doc/example.tmpl
+++ b/static/doc/example.tmpl
@@ -15,7 +15,7 @@
       <p><a class="Documentation-examplesPlay" href="{{.}}">Open in Go playground »</a></p>{{"\n" -}}
       {{- end -}}
       {{render_code .Example}}{{"\n" -}}
-      <pre><span class="Documentation-exampleOutputLabel">Output:</span>{{"\n\n"}}<span class="Documentation-exampleOutput">{{- .Output -}}</span></pre>{{"\n" -}}
+      {{- if .Output -}}<pre><span class="Documentation-exampleOutputLabel">Output:</span>{{"\n\n"}}<span class="Documentation-exampleOutput">{{- .Output -}}</span></pre>{{"\n" -}}{{- end -}}
     </div>{{"\n" -}}
     {{- if .Play -}}
       <div class="Documentation-exampleButtonsContainer">


### PR DESCRIPTION
Fixes golang/go#60986