### PR TITLE
internal/godoc/dochtml: add type parameters on func synopsis

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can check it out at [https://pkg.go.dev](https://pkg.go.dev).
 `pkgsite` program extracts and generates documentation for Go projects.
 
 Example usage:
+
 ```
 $ go install golang.org/x/pkgsite/cmd/pkgsite@latest
 $ cd myproject

--- a/internal/fetch/fetchdata_test.go
+++ b/internal/fetch/fetchdata_test.go
@@ -2845,7 +2845,7 @@ var moduleGenerics = &testModule{
 								{
 									SymbolMeta: internal.SymbolMeta{
 										Name:     "Min",
-										Synopsis: "func Min(a, b T) T",
+										Synopsis: "func Min[T constraints.Ordered](a, b T) T",
 										Section:  "Functions",
 										Kind:     "Function",
 									},

--- a/internal/godoc/dochtml/internal/render/synopsis.go
+++ b/internal/godoc/dochtml/internal/render/synopsis.go
@@ -89,15 +89,17 @@ func OneLineNodeDepth(fset *token.FileSet, node ast.Node, depth int) string {
 			}
 		}
 
+		tparam := formatTypeParams(fset, n.TypeParams, depth)
+
 		param := joinStrings(params)
 		if len(results) == 0 {
-			return fmt.Sprintf("func(%s)", param)
+			return fmt.Sprintf("func%s(%s)", tparam, param)
 		}
 		result := joinStrings(results)
 		if !needParens {
-			return fmt.Sprintf("func(%s) %s", param, result)
+			return fmt.Sprintf("func%s(%s) %s", tparam, param, result)
 		}
-		return fmt.Sprintf("func(%s) (%s)", param, result)
+		return fmt.Sprintf("func%s(%s) (%s)", tparam, param, result)
 
 	case *ast.StructType:
 		if n.Fields == nil || len(n.Fields.List) == 0 {
@@ -213,4 +215,15 @@ func joinStrings(ss []string) string {
 		}
 	}
 	return strings.Join(ss, ", ")
+}
+
+func formatTypeParams(fset *token.FileSet, list *ast.FieldList, depth int) string {
+	if list.NumFields() == 0 {
+		return ""
+	}
+	var tparams []string
+	for _, field := range list.List {
+		tparams = append(tparams, OneLineField(fset, field, depth))
+	}
+	return "[" + joinStrings(tparams) + "]"
 }


### PR DESCRIPTION
Adding type parameters on functions synopsis.

Fixes golang/go#60954