### PR TITLE
internal/godoc/dochtml: enhance output parsing for example func

### DIFF
--- a/internal/godoc/dochtml/internal/render/linkify_test.go
+++ b/internal/godoc/dochtml/internal/render/linkify_test.go
@@ -298,6 +298,18 @@ b := 1
 </pre>
 `,
 		},
+		{
+			"An Output comment must appear at the start of the line.",
+			`_ = true
+// This comment containing "// Output:" is not treated specially.
+`,
+			`
+<pre class="Documentation-exampleCode">
+_ = true
+// This comment containing &#34;// Output:&#34; is not treated specially.
+</pre>
+`,
+		},
 	} {
 		out := codeHTML(test.in, exampleTmpl)
 		got := strings.TrimSpace(string(out.String()))

--- a/internal/godoc/dochtml/internal/render/render.go
+++ b/internal/godoc/dochtml/internal/render/render.go
@@ -21,7 +21,8 @@ import (
 
 var (
 	// Regexp for example outputs.
-	exampleOutputRx = regexp.MustCompile(`(?i)//[[:space:]]*(unordered )?output:`)
+	// Keep consistent with outputPrefix in GOROOT/src/go/doc/example.go.
+	exampleOutputRx = regexp.MustCompile(`(?i)^[[:space:]]*//[[:space:]]*(unordered )?output:`)
 )
 
 type Renderer struct {


### PR DESCRIPTION
Current logic for detecting "concluding line comment" is not strict
enough that it may cause false-positive, causing some normal comment
(and code following it) to be discarded in the rendered web page.

Ensure that "concluding line comment" can only be prefixed by spaces.
Also add corresponding test case.

Fixes golang/go#65450