### PR TITLE
internal/fetch: add versioning for links to std packages

### DIFF
--- a/internal/godoc/dochtml/dochtml.go
+++ b/internal/godoc/dochtml/dochtml.go
@@ -29,6 +29,8 @@ import (
 	"golang.org/x/pkgsite/internal"
 	"golang.org/x/pkgsite/internal/derrors"
 	"golang.org/x/pkgsite/internal/godoc/dochtml/internal/render"
+	"golang.org/x/pkgsite/internal/log"
+	"golang.org/x/pkgsite/internal/stdlib"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -442,15 +444,21 @@ func buildNoteHeaders(notes map[string][]*doc.Note) map[string]noteHeader {
 }
 
 // versionedPkgPath transforms package paths to contain the same version as the
-// current module if the package belongs to the module. As a special case,
-// versionedPkgPath will not add versions to standard library packages.
+// current module if the package belongs to the module.
 func versionedPkgPath(pkgPath string, modInfo *ModuleInfo) string {
-	if modInfo == nil || !modInfo.ModulePackages[pkgPath] {
+	if modInfo != nil && modInfo.ModulePath == "std" {
+		tag, err := stdlib.TagForVersion(modInfo.ResolvedVersion)
+		if err != nil {
+			log.Errorf(context.TODO(), "goTagForVersion(%q): %v", modInfo.ResolvedVersion, err)
+			return pkgPath
+		}
+		return fmt.Sprintf("%s@%s", pkgPath, tag)
+	}
+
+	if modInfo == nil || (!modInfo.ModulePackages[pkgPath]) {
 		return pkgPath
 	}
-	// We don't need to do anything special here for standard library packages
-	// since pkgPath will never contain the "std/" module prefix, and
-	// modInfo.ModulePackages contains this prefix for standard library packages.
+
 	innerPkgPath := pkgPath[len(modInfo.ModulePath):]
 	return fmt.Sprintf("%s@%s%s", modInfo.ModulePath, modInfo.ResolvedVersion, innerPkgPath)
 }

--- a/internal/godoc/dochtml/dochtml_test.go
+++ b/internal/godoc/dochtml/dochtml_test.go
@@ -242,24 +242,24 @@ func TestVersionedPkgPath(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "builtin package is not versioned",
+			name:    "builtin package is versioned",
 			pkgPath: "builtin",
 			modInfo: &ModuleInfo{
 				ModulePath:      "std",
-				ResolvedVersion: "v1.14.4",
+				ResolvedVersion: "v1.14",
 				ModulePackages:  map[string]bool{"std/builtin": true, "std/net/http": true},
 			},
-			want: "builtin",
+			want: "builtin@go1.14",
 		},
 		{
-			name:    "std packages are not versioned",
+			name:    "std packages are versioned",
 			pkgPath: "net/http",
 			modInfo: &ModuleInfo{
 				ModulePath:      "std",
-				ResolvedVersion: "v1.14.4",
+				ResolvedVersion: "v1.23.0",
 				ModulePackages:  map[string]bool{"std/builtin": true, "std/net/http": true},
 			},
-			want: "net/http",
+			want: "net/http@go1.23.0",
 		},
 		{
 			name:    "imports from other modules are not versioned",


### PR DESCRIPTION
It turns out that not including versions in the links to standard library packages can be problematic.

For example, Go 1.23.0 added the iter package and the maps.Keys function.
https://pkg.go.dev/iter@go1.23rc2#hdr-Standard_Library_Usage
This paragraph contains a link to https://pkg.go.dev/maps#Keys, and that link was broken before version 1.23.0 was released.

With this change, versions will always be included in the links to standard library packages.

Fixes: #68755