### PR TITLE
static/frontend: increase percentage of mask-image start

### DIFF
--- a/static/frontend/unit/main/_readme.css
+++ b/static/frontend/unit/main/_readme.css
@@ -31,8 +31,8 @@
 
 .UnitReadme-content {
   /* stylelint-disable-next-line property-no-vendor-prefix */
-  -webkit-mask-image: linear-gradient(to bottom, black 75%, transparent 100%);
-  mask-image: linear-gradient(to bottom, black 75%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 95%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 95%, transparent 100%);
   max-height: 20rem;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
The existing percentage of where the mask-image linear-gradient starts
currently overlaps some links when text-spacing is applied and therefore
decreases the color-contrast ratio of the link making the text less
accessible. This change increases the percentage and thus moves the
gradient to be closer to the end of the container and less likely to
overlap text and links.

Before screenshot:
https://screenshot.googleplex.com/By9T6ZKwv6wxPue)

After screenshot:
https://screenshot.googleplex.com/Ad4J3683xC9sQdH)

Fixes b/365624081
