### PR TITLE
static/frontend: add a11y attributes to interactive elements

### DIFF
--- a/static/frontend/unit/main/_meta.tmpl
+++ b/static/frontend/unit/main/_meta.tmpl
@@ -89,7 +89,7 @@
         <summary class="go-textSubtle">
           {{template "unit-meta-details-check" .Unit.IsRedistributable}}
           Redistributable license
-          <img class="go-Icon" role="button" tabindex="0" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" aria-label="Toggle redistributable help tooltip. height="24" width="24">
+          <img class="go-Icon" role="button" tabindex="0" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" aria-label="Toggle redistributable help tooltip." height="24" width="24">
         </summary>
         <p aria-live="polite" role="tooltip">
           Redistributable licenses place minimal restrictions on how software can be used,

--- a/static/frontend/unit/main/_meta.tmpl
+++ b/static/frontend/unit/main/_meta.tmpl
@@ -59,10 +59,12 @@
 
 {{define "unit-meta-details-check"}}
   <img class="go-Icon{{if .}} go-Icon--accented{{end}}"
+    tabindex="0"
+    role="button"
     {{- if . -}}
-      src="/static/shared/icon/check_circle_gm_grey_24dp.svg" alt="checked"
+      src="/static/shared/icon/check_circle_gm_grey_24dp.svg" alt="checked" aria-label="Valid go.mod file, toggle tooltip"
     {{- else -}}
-      src="/static/shared/icon/cancel_gm_grey_24dp.svg" alt="unchecked"
+      src="/static/shared/icon/cancel_gm_grey_24dp.svg" alt="unchecked" aria-label="Missing or invalid go.mod file, toggle tooltip"
     {{- end -}}
   height="24" width="24">
 {{end}}
@@ -74,9 +76,9 @@
         <summary class="go-textSubtle">
           {{template "unit-meta-details-check" .Unit.HasGoMod}}
           Valid {{if .Unit.HasGoMod}}<a href="{{.Details.ModFileURL}}" target="_blank" rel="noopener">{{end}}go.mod{{if .Unit.HasGoMod}}</a>{{end}} file
-          <img class="go-Icon" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" height="24" width="24">
+          <img class="go-Icon" role="button" tabindex="0" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" aria-label="Toggle go.mod validity tooltip" height="24" width="24">
         </summary>
-        <p>
+        <p aria-live="polite" role="tooltip">
           The Go module system was introduced in Go 1.11 and is the official dependency management
           solution for Go.
         </p>
@@ -87,9 +89,9 @@
         <summary class="go-textSubtle">
           {{template "unit-meta-details-check" .Unit.IsRedistributable}}
           Redistributable license
-          <img class="go-Icon" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" height="24" width="24">
+          <img class="go-Icon" role="button" tabindex="0" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" aria-label="Toggle redistributable help tooltip. height="24" width="24">
         </summary>
-        <p>
+        <p aria-live="polite" role="tooltip">
           Redistributable licenses place minimal restrictions on how software can be used,
           modified, and redistributed.
         </p>
@@ -100,9 +102,9 @@
         <summary class="go-textSubtle">
           {{template "unit-meta-details-check" .Details.IsTaggedVersion}}
           Tagged version
-          <img class="go-Icon" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" height="24" width="24">
+          <img class="go-Icon" role="button" tabindex="0" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" aria-label="Toggle tagged version tooltip" height="24" width="24">
         </summary>
-        <p>Modules with tagged versions give importers more predictable builds.</p>
+        <p aria-live="polite" role="tooltip">Modules with tagged versions give importers more predictable builds.</p>
       </details>
     </li>
     <li>
@@ -110,9 +112,9 @@
         <summary class="go-textSubtle">
           {{template "unit-meta-details-check"  .Details.IsStableVersion}}
           Stable version
-          <img class="go-Icon" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" height="24" width="24">
+          <img class="go-Icon" role="button" tabindex="0" aria-label="Toggle stable version tooltip" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" height="24" width="24">
         </summary>
-        <p>When a project reaches major version v1 it is considered stable.</p>
+        <p aria-live="polite" role="tooltip">When a project reaches major version v1 it is considered stable.</p>
       </details>
     </li>
     <li class="UnitMeta-detailsLearn">

--- a/static/frontend/unit/main/_meta.tmpl
+++ b/static/frontend/unit/main/_meta.tmpl
@@ -62,9 +62,9 @@
     tabindex="0"
     role="button"
     {{- if . -}}
-      src="/static/shared/icon/check_circle_gm_grey_24dp.svg" alt="checked" aria-label="Valid go.mod file, toggle tooltip"
+      src="/static/shared/icon/check_circle_gm_grey_24dp.svg" alt="checked" aria-label="Valid file, toggle tooltip"
     {{- else -}}
-      src="/static/shared/icon/cancel_gm_grey_24dp.svg" alt="unchecked" aria-label="Missing or invalid go.mod file, toggle tooltip"
+      src="/static/shared/icon/cancel_gm_grey_24dp.svg" alt="unchecked" aria-label="Missing or invalid file, toggle tooltip"
     {{- end -}}
   height="24" width="24">
 {{end}}
@@ -89,7 +89,7 @@
         <summary class="go-textSubtle">
           {{template "unit-meta-details-check" .Unit.IsRedistributable}}
           Redistributable license
-          <img class="go-Icon" role="button" tabindex="0" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" aria-label="Toggle redistributable help tooltip." height="24" width="24">
+          <img class="go-Icon" role="button" tabindex="0" src="/static/shared/icon/help_gm_grey_24dp.svg" alt="" aria-label="Toggle redistributable help tooltip" height="24" width="24">
         </summary>
         <p aria-live="polite" role="tooltip">
           Redistributable licenses place minimal restrictions on how software can be used,


### PR DESCRIPTION
Updates interactive elements for unit-meta-details that were previously
not accessible via keyboard to have appropriate a11y attributes such as
roles, tabindex, and aria-live to improve the overall accessible 
interactions with the meta- details and make it keyboard and
screenreader friendly.

Before screenshots:
-icons:
https://screenshot.googleplex.com/4eqbZ7ps58yCWwT
-tooltip:
https://screenshot.googleplex.com/6qzZ9wdtBpfXszy

After:
-icon screenshot updates:
https://screenshot.googleplex.com/7kbHJk4tYv2naQf
-tooltip screenshot updates:
https://screenshot.googleplex.com/8ZwutWMTS2FNkwy

Fixes b/283533035