### PR TITLE
static/frontend: add search aria-describedby

### DIFF
--- a/static/frontend/homepage/homepage.tmpl
+++ b/static/frontend/homepage/homepage.tmpl
@@ -21,6 +21,7 @@
           id="AutoComplete"
           role="textbox"
           aria-label="{{.SearchPrompt}}"
+          aria-describedby="SearchTipContent"
           type="search"
           name="q"
           placeholder="{{.SearchPrompt}}"
@@ -35,7 +36,7 @@
       <section class="go-Carousel Homepage-tips js-carousel" aria-label="Search Tips Carousel" data-slide-index="{{.TipIndex}}">
         <ul>
           {{range $i, $v := .SearchTips}}
-            <li class="go-Carousel-slide" {{if not (eq $.TipIndex $i)}}aria-hidden{{end}}>
+            <li class="go-Carousel-slide" {{if not (eq $.TipIndex $i)}}aria-hidden{{end}} {{if (eq $.TipIndex $i)}}id="SearchTipContent"{{end}}>
               <p>
                 <strong>Tip:</strong> {{.Text}}
                 <a href="/search?q={{$v.Example1}}">“{{$v.Example1}}”</a> or


### PR DESCRIPTION
Currently the search input aria-label is static and when
focused on by a screen reader, the screen reader does
not read the search tip found below the input. This
change checks the .TipIndex value and if it
matches adds the id=SearchTipContent which the input's
aria-describedby is attached to, thus allowing the visible
tip/description to be read as supplemental info after the
input's existing aria-label.

Before screenshot:
https://screenshot.googleplex.com/AkAmQ69s4R3NsZS

After screenshot:
https://screenshot.googleplex.com/94MwK6bXpSBE6Gr

Fixes b/283297190