### PR TITLE
internal/fetch: add correct canonical path for IBM/sarama

### DIFF
--- a/internal/fetch/known_alternatives.go
+++ b/internal/fetch/known_alternatives.go
@@ -28,6 +28,7 @@ var knownAlternatives = map[string]string{
 	"github.com/aliyun/alibaba-cloud-sdk-go":           "github.com/Azure/azure-sdk-for-go",
 	"github.com/johnstairs/azure-sdk-for-go":           "github.com/Azure/azure-sdk-for-go",
 	"github.com/shopify/sarama":                        "github.com/Shopify/sarama",
+	"github.com/ibm/sarama":                            "github.com/IBM/sarama",
 }
 
 // knownAlternativeFor returns the module that the given module path is an alternative to,


### PR DESCRIPTION
Similar to golang/go#52192 we need to add lowercase ibm/sarama to the
knownAlternatives map to ensure the canonical uppercase variant 
(asdefined in go.mod) is chosen in preference.

Fixes golang/go#71256